### PR TITLE
Adds software back button in toolbar

### DIFF
--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionShareActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionShareActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -133,6 +134,7 @@ public class AttractionShareActivity extends AppCompatActivity {
         setTitle(getString(R.string.attraction_share_title, attractionName));
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         callbackManager = CallbackManager.Factory.create();
 
@@ -207,5 +209,16 @@ public class AttractionShareActivity extends AppCompatActivity {
         super.onActivityResult(requestCode, resultCode, data);
         callbackManager.onActivityResult(requestCode, resultCode, data);
         loginButton.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 }

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionTabsActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionTabsActivity.java
@@ -17,8 +17,6 @@ import android.view.MenuItem;
 import com.facebook.CallbackManager;
 
 import ar.uba.fi.tdp2.trips.Common.OnFragmentInteractionListener;
-import ar.uba.fi.tdp2.trips.Multimedia.GalleryFragment;
-import ar.uba.fi.tdp2.trips.PointsOfInterest.PointOfInterestFragment;
 import ar.uba.fi.tdp2.trips.R;
 
 public class AttractionTabsActivity extends AppCompatActivity implements TabLayout.OnTabSelectedListener, OnFragmentInteractionListener {
@@ -55,7 +53,7 @@ public class AttractionTabsActivity extends AppCompatActivity implements TabLayo
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-//        getSupportActionBar().setDisplayHomeAsUpEnabled(true); // TODO enable for back-button
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true); // TODO enable for back-button
 
         //Initializing the tablayout
         tabLayout = (TabLayout) findViewById(R.id.tab_layout);
@@ -174,6 +172,17 @@ public class AttractionTabsActivity extends AppCompatActivity implements TabLayo
         });
 
         return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 
     @Override

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/AttractionsToursTabsActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/AttractionsToursTabsActivity.java
@@ -54,7 +54,7 @@ public class AttractionsToursTabsActivity extends ActivityWithCallbackManager im
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-//        getSupportActionBar().setDisplayHomeAsUpEnabled(true); // TODO enable for back-button
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true); // TODO enable for back-button
 
         //Initializing the tablayout
         tabLayout = (TabLayout) findViewById(R.id.tab_layout);
@@ -120,6 +120,17 @@ public class AttractionsToursTabsActivity extends ActivityWithCallbackManager im
         });
 
         return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 
     @Override

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Tours/TourDetailsActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Tours/TourDetailsActivity.java
@@ -3,6 +3,7 @@ package ar.uba.fi.tdp2.trips.AttractionsTours.Tours;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
 
 import ar.uba.fi.tdp2.trips.Common.ActivityWithCallbackManager;
 import ar.uba.fi.tdp2.trips.Common.OnFragmentInteractionListener;
@@ -26,6 +27,19 @@ public class TourDetailsActivity extends ActivityWithCallbackManager implements 
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         toolbar.setTitle(tourName);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true); // TODO enable for back-button
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 
     @Override

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/PointsOfInterest/PointOfInterestTabsActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/PointsOfInterest/PointOfInterestTabsActivity.java
@@ -8,6 +8,7 @@ import android.support.v7.widget.Toolbar;
 import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.os.Bundle;
+import android.view.MenuItem;
 
 import ar.uba.fi.tdp2.trips.Common.OnFragmentInteractionListener;
 import ar.uba.fi.tdp2.trips.R;
@@ -37,7 +38,7 @@ public class PointOfInterestTabsActivity extends AppCompatActivity implements Ta
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
-        //getSupportActionBar().setDisplayHomeAsUpEnabled(true); // TODO for back-arrow in navbar
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true); // TODO for back-arrow in navbar
 
         //Initializing the tablayout
         tabLayout = (TabLayout) findViewById(R.id.tab_layout);
@@ -61,6 +62,17 @@ public class PointOfInterestTabsActivity extends AppCompatActivity implements Ta
 
         //Adding onTabSelectedListener to swipe views
         tabLayout.setOnTabSelectedListener(this);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 
     @Override

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Reviews/AllReviewsActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Reviews/AllReviewsActivity.java
@@ -7,6 +7,7 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
+import android.view.MenuItem;
 import android.widget.Toast;
 
 import java.util.List;
@@ -42,6 +43,7 @@ public class AllReviewsActivity extends AppCompatActivity {
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         this.setTitle(attractionName);
         System.out.println("SET TITLE: " + attractionName);
@@ -68,5 +70,16 @@ public class AllReviewsActivity extends AppCompatActivity {
                 Log.d(Utils.LOGTAG, t.toString());
             }
         });
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
     }
 }


### PR DESCRIPTION
Agrega en todas las activities el botón por software de "Up". Hace lo mismo que el botón por hardware, es decir, cierra la pantalla actual y muestra la anterior (sin volver a instanciarla).