### PR TITLE
Extract login

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
                 android:value=".AttractionsTours.Attractions.AttractionTabsActivity" />
         </activity>
         <activity
-            android:name=".AttractionsTours.Attractions.AttractionShareActivity"
+            android:name=".AttractionsTours.Attractions.SessionActivity"
             android:theme="@style/AppTheme.NoActionBar">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionDetailsFragment.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionDetailsFragment.java
@@ -1,6 +1,5 @@
 package ar.uba.fi.tdp2.trips.AttractionsTours.Attractions;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -24,7 +23,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
-import com.facebook.CallbackManager;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;
@@ -63,7 +61,6 @@ public class AttractionDetailsFragment extends Fragment implements OnMapReadyCal
     public Attraction attraction; // Accessed by review modal
     private OnFragmentInteractionListener mListener;
     private Context localContext;
-    public CallbackManager callbackManager;
 
     public AttractionDetailsFragment() {
         // Required empty public constructor
@@ -95,7 +92,7 @@ public class AttractionDetailsFragment extends Fragment implements OnMapReadyCal
         if (getArguments() != null) {
             attractionId = getArguments().getInt(ARG_ATTRACTION_ID);
         }
-        callbackManager = ((AttractionTabsActivity) getActivity()).callbackManager;
+//        callbackManager = ((AttractionTabsActivity) getActivity()).callbackManager; // TODO go to login instead
         localContext = getContext();
     }
 
@@ -222,18 +219,8 @@ public class AttractionDetailsFragment extends Fragment implements OnMapReadyCal
                 if (user != null) {
                     openWriteReviewDialog();
                 } else {
-                    User.loginWithSocialNetwork((Activity) activityContext,
-                            callbackManager,
-                            localContext.getSharedPreferences("user", 0),
-                            new User.Callback() {
-                                @Override
-                                public void onSuccess(User user) {
-                                    Toast.makeText(localContext, R.string.wait_a_second, Toast.LENGTH_LONG).show();
-                                    openWriteReviewDialog();
-                                }
-                                @Override
-                                public void onError(User user) {}
-                            });
+                    Intent intent = new Intent(localContext, SessionActivity.class);
+                    startActivityForResult(intent, SessionActivity.RequestCode.REVIEW);
                 }
 
 
@@ -362,8 +349,20 @@ public class AttractionDetailsFragment extends Fragment implements OnMapReadyCal
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        callbackManager.onActivityResult(requestCode, resultCode, data);
+        switch (requestCode) {
+            case SessionActivity.RequestCode.REVIEW:
+                Toast.makeText(localContext, "RequestCode REVIEW", Toast.LENGTH_SHORT).show();
+                User user = User.getInstance(localContext.getSharedPreferences("user", 0));
+                if (user != null) {
+                    openWriteReviewDialog();
+                } else {
+                    Toast.makeText(localContext, "USER IS NULL", Toast.LENGTH_LONG).show();
+                }
+                break;
+            default:
+                Toast.makeText(localContext, "RequestCode WRONG (fragment): " + requestCode, Toast.LENGTH_LONG).show();
+                super.onActivityResult(requestCode, resultCode, data);
+        }
     }
 
     @Override

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionTabsActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionTabsActivity.java
@@ -1,6 +1,5 @@
 package ar.uba.fi.tdp2.trips.AttractionsTours.Attractions;
 
-import android.content.Context;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.net.Uri;
@@ -13,9 +12,9 @@ import android.support.v4.view.ViewPager;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.widget.Toast;
 
-import com.facebook.CallbackManager;
-
+import ar.uba.fi.tdp2.trips.AttractionsTours.Attractions.SessionActivity.RequestCode;
 import ar.uba.fi.tdp2.trips.Common.OnFragmentInteractionListener;
 import ar.uba.fi.tdp2.trips.R;
 
@@ -37,13 +36,10 @@ public class AttractionTabsActivity extends AppCompatActivity implements TabLayo
 
     private TabLayout tabLayout;
     public int attractionId; // Accessed by fragments
-    public CallbackManager callbackManager;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
-        callbackManager = CallbackManager.Factory.create();
 
         setContentView(R.layout.activity_attraction_tabs);
 
@@ -100,73 +96,22 @@ public class AttractionTabsActivity extends AppCompatActivity implements TabLayo
 
     }
 
-    private void openAttractionShareDialog() {
-        //AttractionShareActivity shareFragment = new AttractionShareActivity();
-        //Bundle bundle = new Bundle();
-        //bundle.putCharSequence("attractionName", getTitle());
-        //shareFragment.setArguments(bundle);
-        //shareFragment.show(getFragmentManager(), "tag");
-///////
-        Intent intent = new Intent(this, AttractionShareActivity.class);
+    private void loginForSharing() {
+        Intent intent = new Intent(this, SessionActivity.class);
         intent.putExtra("attractionName", getTitle());
-        startActivity(intent);
+        startActivityForResult(intent, RequestCode.SHARE);
     }
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.menu_share, menu);
 
-        final Context activityContext = this;
-
         MenuItem item = menu.findItem(R.id.attraction_share);
         item.getIcon().setColorFilter(getResources().getColor(R.color.toolbarContent), PorterDuff.Mode.SRC_IN);
         item.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
             @Override
             public boolean onMenuItemClick(MenuItem item) {
-                openAttractionShareDialog();
-                /*
-                User user = User.getInstance(getSharedPreferences("user", 0));
-                if (user != null && user.fbPost && user.fbPublicProfile) {
-                    openAttractionShareDialog();
-                    return false;
-                }
-                if (user != null && !user.fbPost) {
-                    user.getFbPostPermissions((Activity) activityContext, callbackManager,
-                            getSharedPreferences("user", 0),
-                            new User.Callback() {
-                                @Override
-                                public void onSuccess(User user) {
-                                    openAttractionShareDialog();
-                                }
-                                @Override
-                                public void onError(User user) {}
-                            });
-                } else {
-                    User.loginWithSocialNetwork((Activity) activityContext,
-                            callbackManager,
-                            getSharedPreferences("user", 0),
-                            new User.Callback() {
-                                @Override
-                                public void onSuccess(User user) {
-                                        Toast.makeText(activityContext, R.string.wait_a_second, Toast.LENGTH_LONG).show();
-                                    user.getFbPostPermissions((Activity) activityContext, callbackManager,
-                                            getSharedPreferences("user", 0),
-                                            new User.Callback() {
-                                                @Override
-                                                public void onSuccess(User user) {
-                                                    openAttractionShareDialog();
-                                                }
-                                                @Override
-                                                public void onError(User user) {}
-                                            });
-                                }
-                                @Override
-                                public void onError(User user) {}
-                            });
-                }
-                */
-
-
+                loginForSharing();
                 return false;
             }
         });
@@ -187,8 +132,18 @@ public class AttractionTabsActivity extends AppCompatActivity implements TabLayo
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        callbackManager.onActivityResult(requestCode, resultCode, data);
+        switch (requestCode) {
+            case RequestCode.SHARE:
+                Toast.makeText(this, "RequestCode SHARE", Toast.LENGTH_LONG).show();
+                // TODO open share fragment
+                break;
+            case RequestCode.REVIEW:
+                Toast.makeText(this, "RequestCode REVIEW", Toast.LENGTH_LONG).show();
+                break;
+            default:
+                Toast.makeText(this, "RequestCode WRONG (activity): " + requestCode, Toast.LENGTH_LONG).show();
+                super.onActivityResult(requestCode, resultCode, data);
+        }
     }
 
 }

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionTabsActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/AttractionTabsActivity.java
@@ -1,9 +1,12 @@
 package ar.uba.fi.tdp2.trips.AttractionsTours.Attractions;
 
+import android.app.FragmentTransaction;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.net.Uri;
 import android.support.design.widget.TabLayout;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 
@@ -16,6 +19,7 @@ import android.widget.Toast;
 
 import ar.uba.fi.tdp2.trips.AttractionsTours.Attractions.SessionActivity.RequestCode;
 import ar.uba.fi.tdp2.trips.Common.OnFragmentInteractionListener;
+import ar.uba.fi.tdp2.trips.Common.User;
 import ar.uba.fi.tdp2.trips.R;
 
 public class AttractionTabsActivity extends AppCompatActivity implements TabLayout.OnTabSelectedListener, OnFragmentInteractionListener {
@@ -36,6 +40,7 @@ public class AttractionTabsActivity extends AppCompatActivity implements TabLayo
 
     private TabLayout tabLayout;
     public int attractionId; // Accessed by fragments
+    private String attractionName;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -44,7 +49,7 @@ public class AttractionTabsActivity extends AppCompatActivity implements TabLayo
         setContentView(R.layout.activity_attraction_tabs);
 
         Bundle bundle = getIntent().getExtras();
-        String attractionName = bundle.getString("attractionName");
+        attractionName = bundle.getString("attractionName");
         this.setTitle(attractionName);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
@@ -132,18 +137,22 @@ public class AttractionTabsActivity extends AppCompatActivity implements TabLayo
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        switch (requestCode) {
-            case RequestCode.SHARE:
-                Toast.makeText(this, "RequestCode SHARE", Toast.LENGTH_LONG).show();
-                // TODO open share fragment
-                break;
-            case RequestCode.REVIEW:
-                Toast.makeText(this, "RequestCode REVIEW", Toast.LENGTH_LONG).show();
-                break;
-            default:
-                Toast.makeText(this, "RequestCode WRONG (activity): " + requestCode, Toast.LENGTH_LONG).show();
-                super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode != RequestCode.SHARE) {
+            super.onActivityResult(requestCode, resultCode, data);
+            return;
         }
+
+        User user = User.getInstance(getSharedPreferences("user", 0));
+        if (user == null) {
+            return;
+        }
+        String initialText = String.format("%s %s!", getString(R.string.attraction_post_message), attractionName);
+
+        ShareAttractionFragment shareAttractionFragment = ShareAttractionFragment.newInstance(initialText);
+
+        getSupportFragmentManager().beginTransaction()
+                .add(shareAttractionFragment, "shareAttractionDialog")
+                .commitAllowingStateLoss();
     }
 
 }

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/SessionActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/SessionActivity.java
@@ -8,8 +8,6 @@ import android.support.v7.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.Button;
-import android.widget.EditText;
 import android.widget.Toast;
 
 import com.facebook.CallbackManager;
@@ -23,12 +21,19 @@ import com.twitter.sdk.android.core.identity.TwitterLoginButton;
 import ar.uba.fi.tdp2.trips.R;
 import ar.uba.fi.tdp2.trips.Common.User;
 
-public class AttractionShareActivity extends AppCompatActivity {
+public class SessionActivity extends AppCompatActivity {
 
     public CallbackManager callbackManager;
-    private CharSequence attractionName;
-    private TwitterLoginButton loginButton;
+//    private CharSequence attractionName;
+    private TwitterLoginButton twLoginButton;
     private LoginButton fbLoginButton;
+
+    public static class RequestCode {
+        public static final int SHARE = 1;
+        public static final int REVIEW = 2;
+        public static final int FAVORITE = 3;
+        public static final int VISITED = 4;
+    }
 
     @Override
     public void onResume() {
@@ -40,6 +45,11 @@ public class AttractionShareActivity extends AppCompatActivity {
         final Activity me = this;
         User user = User.getInstance(getSharedPreferences("user", 0));
 
+        fbLogin(me, user);
+        twLogin(user);
+    }
+
+    public void fbLogin(final Activity me, User user) {
         fbLoginButton = (LoginButton) findViewById(R.id.facebook_login_button);
         if (user == null || user.fbUserId == null || !user.fbPublicProfile || !user.fbPost) {
             findViewById(R.id.fb_logo).setVisibility(View.GONE);
@@ -66,7 +76,7 @@ public class AttractionShareActivity extends AppCompatActivity {
                             public void onError(User user) {}
                         },
                         fbLoginButton);
-            } else if(!user.fbPost) {
+            } else if (!user.fbPost) {
                 User.postWithFacebook(
                         callbackManager,
                         getSharedPreferences("user", 0),
@@ -84,16 +94,16 @@ public class AttractionShareActivity extends AppCompatActivity {
             findViewById(R.id.fb_logo).setVisibility(View.VISIBLE);
             fbLoginButton.setVisibility(View.GONE);
         }
+    }
 
-        loginButton = (TwitterLoginButton) findViewById(R.id.twitter_login_button);
-        loginButton.setCallback(new Callback<TwitterSession>() {
+    public void twLogin(User user) {
+        twLoginButton = (TwitterLoginButton) findViewById(R.id.twitter_login_button);
+        twLoginButton.setCallback(new Callback<TwitterSession>() {
             @Override
             public void success(Result<TwitterSession> result) {
                 // The TwitterSession is also available through:
                 // Twitter.getInstance().core.getSessionManager().getActiveSession()
                 TwitterSession session = result.data;
-                // TODO: Remove toast and use the TwitterSession's userID
-                // with your app's user model
                 User.createFromTwToken(
                         String.valueOf(session.getUserId()),
                         session.getAuthToken().token,
@@ -120,69 +130,70 @@ public class AttractionShareActivity extends AppCompatActivity {
             findViewById(R.id.tw__twitter_logo).setVisibility(View.GONE);
         } else {
             findViewById(R.id.tw__twitter_logo).setVisibility(View.VISIBLE);
-            loginButton.setVisibility(View.GONE);
+            twLoginButton.setVisibility(View.GONE);
         }
     }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.fragment_attraction_share);
+        setContentView(R.layout.activity_session);
 
-        Bundle bundle = getIntent().getExtras();
-        attractionName = bundle.getCharSequence("attractionName");
-        setTitle(getString(R.string.attraction_share_title, attractionName));
+//        Bundle bundle = getIntent().getExtras();
+//        attractionName = bundle.getCharSequence("attractionName");
+//        setTitle(getString(R.string.attraction_share_title, attractionName));
+        setTitle(getString(R.string.manage_sessions));
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         callbackManager = CallbackManager.Factory.create();
 
-        final EditText message = (EditText) findViewById(R.id.message);
-        message.setText(getString(R.string.attraction_post_message) + " " + attractionName + "!");
+//        final EditText message = (EditText) findViewById(R.id.message);
+//        message.setText(getString(R.string.attraction_post_message) + " " + attractionName + "!");
     }
 
-    public void cancel(View view) {
-        finish();
-    }
+//    public void cancel(View view) {
+//        finish();
+//    }
 
-    public void send(View view) {
-        User user = User.getInstance(getSharedPreferences("user", 0));
-        System.out.println(user);
-        final Button button = (Button) view;
-        button.setClickable(false);
-        button.setText(R.string.sending);
-        if (user != null) {
-            final EditText message = (EditText) findViewById(R.id.message);
-            final Activity activity = this;
-            user.postInSocialNetwork(message.getText().toString(), new User.Callback() {
-                @Override
-                public void onSuccess(User user) {
-                    button.setClickable(true);
-                    button.setText(R.string.send);
-                    Toast.makeText(activity, R.string.attraction_share_ok,
-                            Toast.LENGTH_LONG).show();
-                    finish();
-                }
-
-                @Override
-                public void onError(User user) {
-                    button.setClickable(true);
-                    button.setText(R.string.send);
-                    Toast.makeText(activity, R.string.attraction_share_error,
-                            Toast.LENGTH_LONG).show();
-                }
-            });
-        } else {
-            System.out.println("Error grave");
-        }
-    }
+//    public void send(View view) {
+//        User user = User.getInstance(getSharedPreferences("user", 0));
+//        System.out.println(user);
+//        final Button button = (Button) view;
+//        button.setClickable(false);
+//        button.setText(R.string.sending);
+//        if (user != null) {
+//            final EditText message = (EditText) findViewById(R.id.message);
+//            final Activity activity = this;
+//            user.postInSocialNetwork(message.getText().toString(), new User.Callback() {
+//                @Override
+//                public void onSuccess(User user) {
+//                    button.setClickable(true);
+//                    button.setText(R.string.done);
+//                    Toast.makeText(activity, R.string.attraction_share_ok,
+//                            Toast.LENGTH_LONG).show();
+//                    finish();
+//                }
+//
+//                @Override
+//                public void onError(User user) {
+//                    button.setClickable(true);
+//                    button.setText(R.string.done);
+//                    Toast.makeText(activity, R.string.attraction_share_error,
+//                            Toast.LENGTH_LONG).show();
+//                }
+//            });
+//        } else {
+//            System.out.println("Error grave");
+//        }
+//    }
 
     /*@Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         final EditText message = (EditText) view.findViewById(R.id.message);
         message.setText(getString(R.string.attraction_post_message) + getArguments().getCharSequence("attractionName") + "!");
-        final AttractionShareActivity fragment = this;
+        final SessionActivity fragment = this;
         builder.setView(view)
                 .setPositiveButton(R.string.send, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
@@ -208,7 +219,7 @@ public class AttractionShareActivity extends AppCompatActivity {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         callbackManager.onActivityResult(requestCode, resultCode, data);
-        loginButton.onActivityResult(requestCode, resultCode, data);
+        twLoginButton.onActivityResult(requestCode, resultCode, data);
     }
 
     @Override
@@ -220,5 +231,9 @@ public class AttractionShareActivity extends AppCompatActivity {
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    public void onDoneButtonClick(View view) {
+        finish();
     }
 }

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/SessionActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/SessionActivity.java
@@ -24,7 +24,6 @@ import ar.uba.fi.tdp2.trips.Common.User;
 public class SessionActivity extends AppCompatActivity {
 
     public CallbackManager callbackManager;
-//    private CharSequence attractionName;
     private TwitterLoginButton twLoginButton;
     private LoginButton fbLoginButton;
 
@@ -138,82 +137,13 @@ public class SessionActivity extends AppCompatActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_session);
-
-//        Bundle bundle = getIntent().getExtras();
-//        attractionName = bundle.getCharSequence("attractionName");
-//        setTitle(getString(R.string.attraction_share_title, attractionName));
         setTitle(getString(R.string.manage_sessions));
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         callbackManager = CallbackManager.Factory.create();
-
-//        final EditText message = (EditText) findViewById(R.id.message);
-//        message.setText(getString(R.string.attraction_post_message) + " " + attractionName + "!");
     }
-
-//    public void cancel(View view) {
-//        finish();
-//    }
-
-//    public void send(View view) {
-//        User user = User.getInstance(getSharedPreferences("user", 0));
-//        System.out.println(user);
-//        final Button button = (Button) view;
-//        button.setClickable(false);
-//        button.setText(R.string.sending);
-//        if (user != null) {
-//            final EditText message = (EditText) findViewById(R.id.message);
-//            final Activity activity = this;
-//            user.postInSocialNetwork(message.getText().toString(), new User.Callback() {
-//                @Override
-//                public void onSuccess(User user) {
-//                    button.setClickable(true);
-//                    button.setText(R.string.done);
-//                    Toast.makeText(activity, R.string.attraction_share_ok,
-//                            Toast.LENGTH_LONG).show();
-//                    finish();
-//                }
-//
-//                @Override
-//                public void onError(User user) {
-//                    button.setClickable(true);
-//                    button.setText(R.string.done);
-//                    Toast.makeText(activity, R.string.attraction_share_error,
-//                            Toast.LENGTH_LONG).show();
-//                }
-//            });
-//        } else {
-//            System.out.println("Error grave");
-//        }
-//    }
-
-    /*@Override
-    public Dialog onCreateDialog(Bundle savedInstanceState) {
-        final EditText message = (EditText) view.findViewById(R.id.message);
-        message.setText(getString(R.string.attraction_post_message) + getArguments().getCharSequence("attractionName") + "!");
-        final SessionActivity fragment = this;
-        builder.setView(view)
-                .setPositiveButton(R.string.send, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        User user = User.getInstance(getActivity().getSharedPreferences("user", 0));
-                        System.out.println(user);
-                        if (user != null) {
-                            user.postInSocialNetwork(fragment,
-                                    fragment.callbackManager,
-                                    message.getText().toString());
-                        } else {
-                            System.out.println("Error grave");
-                        }
-                    }
-                })
-                .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {}
-                });
-        // Create the AlertDialog object and return it
-        return builder.create();
-    }*/
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/ShareAttractionFragment.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/ShareAttractionFragment.java
@@ -53,16 +53,15 @@ public class ShareAttractionFragment extends DialogFragment {
         final AttractionTabsActivity activity = (AttractionTabsActivity) getActivity();
         LayoutInflater inflater = activity.getLayoutInflater();
         AlertDialog.Builder builder = new AlertDialog.Builder(activity);
-        View view = inflater.inflate(R.layout.fragment_share_attraction, null); // TODO MAKE NEW LAYOUT
+        View view = inflater.inflate(R.layout.fragment_share_attraction, null);
 
         final EditText message = (EditText) view.findViewById(R.id.message);
         message.setText(text);
+        // TODO disable confirm if text is empty
 
         builder.setView(view)
                 .setPositiveButton(R.string.confirm, new DialogInterface.OnClickListener() {
                     public void onClick(DialogInterface dialog, int id) {
-                        // TODO POST SHARE
-                        Toast.makeText(context, "SHARE ATTRACTION", Toast.LENGTH_SHORT).show();
                         User user = User.getInstance(activity.getSharedPreferences("user", 0));
                         System.out.println(user);
                         user.postInSocialNetwork(message.getText().toString(), new User.Callback() {

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/ShareAttractionFragment.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/AttractionsTours/Attractions/ShareAttractionFragment.java
@@ -1,0 +1,92 @@
+package ar.uba.fi.tdp2.trips.AttractionsTours.Attractions;
+
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.app.FragmentManager;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.DialogFragment;
+import android.support.v4.app.FragmentTransaction;
+import android.support.v7.app.AlertDialog;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.Toast;
+
+import ar.uba.fi.tdp2.trips.Common.User;
+import ar.uba.fi.tdp2.trips.Common.Utils;
+import ar.uba.fi.tdp2.trips.R;
+
+
+public class ShareAttractionFragment extends DialogFragment {
+
+    private static final String ARG_TEXT = "text";
+    private String text;
+    private Context context;
+
+    public static ShareAttractionFragment newInstance(String text) {
+        ShareAttractionFragment fragment = new ShareAttractionFragment();
+        // Supply index input as an argument.
+        Bundle args = new Bundle();
+        args.putString(ARG_TEXT, text);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstance) {
+        super.onCreate(savedInstance);
+        Bundle args = getArguments();
+        if (args != null) {
+            text = args.getString(ARG_TEXT);
+        }
+        context = getContext();
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstance) {
+        final AttractionTabsActivity activity = (AttractionTabsActivity) getActivity();
+        LayoutInflater inflater = activity.getLayoutInflater();
+        AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        View view = inflater.inflate(R.layout.fragment_share_attraction, null); // TODO MAKE NEW LAYOUT
+
+        final EditText message = (EditText) view.findViewById(R.id.message);
+        message.setText(text);
+
+        builder.setView(view)
+                .setPositiveButton(R.string.confirm, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        // TODO POST SHARE
+                        Toast.makeText(context, "SHARE ATTRACTION", Toast.LENGTH_SHORT).show();
+                        User user = User.getInstance(activity.getSharedPreferences("user", 0));
+                        System.out.println(user);
+                        user.postInSocialNetwork(message.getText().toString(), new User.Callback() {
+                            @Override
+                            public void onSuccess(User user) {
+                                Toast.makeText(activity, R.string.attraction_share_ok,
+                                        Toast.LENGTH_LONG).show();
+                            }
+
+                            @Override
+                            public void onError(User user) {
+                                Toast.makeText(activity, R.string.attraction_share_error,
+                                        Toast.LENGTH_LONG).show();
+                            }
+                        });
+                    }
+                })
+                .setNegativeButton(R.string.cancel, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        Log.d(Utils.LOGTAG, "cancel review");
+                    }
+                });
+        // Create the AlertDialog object and return it
+        return builder.create();
+    }
+}
+

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Common/User.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Common/User.java
@@ -75,6 +75,7 @@ public class User {
         }
         user.fbUserId = fbUserId;
         user.fbToken = fbToken;
+
         Call<User> call = backendService.createUser(user);
 
         call.enqueue(new retrofit2.Callback<User>() {
@@ -83,6 +84,8 @@ public class User {
                 if (response.body() == null) {
                     return;
                 }
+                user.id = response.body().id;
+                user.token = response.body().token;
                 user.fbPublicProfile = true;
                 user.persistUser(settings);
                 callback.onSuccess(user);
@@ -117,9 +120,10 @@ public class User {
             @Override
             public void onResponse(Call<User> call, Response<User> response) {
                 if (response.body() == null) {
-                    Log.d("TRIPS", "came with response: " + response.toString());
                     return;
                 }
+                user.id = response.body().id;
+                user.token = response.body().token;
                 Log.d("TRIPS", "got user: " + response.body().toString());
                 user.persistUser(settings);
                 callback.onSuccess(user);
@@ -150,6 +154,7 @@ public class User {
         boolean fbPost = settings.getBoolean("userFbPost", false);
         String fbUserId = settings.getString("fbUserId", null);
         String twUserId = settings.getString("twUserId", null);
+        Log.d("TRIPS", userId + " " + userToken);
         if (userId != 0 && userToken != null) {
             User user = new User();
             user.id = userId;

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Common/User.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Common/User.java
@@ -1,6 +1,7 @@
 package ar.uba.fi.tdp2.trips.Common;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.Looper;
@@ -19,6 +20,7 @@ import com.google.gson.annotations.SerializedName;
 import java.io.IOException;
 import java.util.Arrays;
 
+import ar.uba.fi.tdp2.trips.R;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -133,7 +135,8 @@ public class User {
             public void onFailure(Call<User> call, Throwable t) {
                 user = null;
                 t.printStackTrace();
-                Toast.makeText(getApplicationContext(), "No se pudo conectar con el servidor", Toast.LENGTH_LONG).show(); // TODO internationalize
+                Context context = getApplicationContext();
+                Toast.makeText(context, context.getString(R.string.no_server_error), Toast.LENGTH_LONG).show();
                 Log.d("TRIPS", t.toString());
             }
         });

--- a/app/src/main/res/layout/activity_session.xml
+++ b/app/src/main/res/layout/activity_session.xml
@@ -52,25 +52,13 @@
         android:id="@+id/twitter_login_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
         android:layout_centerInParent="true"/>
-    <EditText
-        android:id="@+id/message"
-        android:layout_width="match_parent"
-        android:layout_marginLeft="10dp"
-        android:layout_marginRight="10dp"
-        android:layout_height="wrap_content"
-        android:ems="10"
-        android:hint="@string/write_here"
-        android:inputType="textMultiLine" />
-    <Button
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/cancel"
-        android:onClick="cancel" />
-    <Button
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/send"
-        android:onClick="send" />
+
+    <!--<Button-->
+        <!--android:layout_width="wrap_content"-->
+        <!--android:layout_height="wrap_content"-->
+        <!--android:text="@string/done"-->
+        <!--android:onClick="onDoneButtonClick" />-->
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_share_attraction.xml
+++ b/app/src/main/res/layout/fragment_share_attraction.xml
@@ -1,0 +1,18 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content">
+
+    <EditText
+        android:id="@+id/message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ems="10"
+        android:hint="@string/write_here"
+        android:layout_marginTop="16dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginEnd="16dp"
+        android:inputType="textMultiLine" />
+</LinearLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -33,7 +33,7 @@
     <string name="attraction_share_ok">Your message was shared</string>
     <string name="attraction_share_error">There was an error when sharing your message</string>
     <string name="attraction_post_message">Trips helped me get to know more about</string>
-    <string name="send">Send</string>
+    <string name="done">Done</string>
     <string name="sending">Sending</string>
     <string name="wait_a_second">Wait a second</string>
     <string name="cancel">Cancel</string>
@@ -55,4 +55,5 @@
     <string name="nav_menu_cities">Cities</string>
     <string name="nav_menu_close_session">Close session</string>
     <string name="nav_menu_notifications">Notifications</string>
+    <string name="manage_sessions">Manage sessions</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,7 +45,7 @@
     <string name="attraction_share_ok">Se compartió su mensaje</string>
     <string name="attraction_share_error">Hubo un error al compartir su mensaje</string>
     <string name="attraction_post_message">Trips me ayudó a conocer más de</string>
-    <string name="send">Enviar</string>
+    <string name="done">Listo</string>
     <string name="sending">Enviando</string>
     <string name="cancel">Cancelar</string>
     <string name="wait_a_second">Espere un momento</string>
@@ -67,4 +67,5 @@
 
     <string name="navigation_drawer_open" translatable="false">Open navigation drawer</string>
     <string name="navigation_drawer_close" translatable="false">Close navigation drawer</string>
+    <string name="manage_sessions">Administrar sesiones</string>
 </resources>


### PR DESCRIPTION
Convierte la activity de compartir atracción en una activity de login (reusable) y crea un `dialog` para el texto del post. 

La `SessionActivity` define varios `RequestCodes` a ser usados por quienes la llamen a modo de identificar qué acción deben hacer luego del login. Por ejemplo, la lista de atracciones va a tener que llamar a la `SessionActivity` cuando un usuario marque una atracción como visitada o favorita. En ese caso, el request code permite distinguir al retornar del login qué acción se debe hacer.