### PR TITLE
Adds round user image on sidebar (instead of app logo)

### DIFF
--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Cities/InitialActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Cities/InitialActivity.java
@@ -20,10 +20,12 @@ import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
 
+import com.bumptech.glide.Glide;
 import com.twitter.sdk.android.Twitter;
 import com.twitter.sdk.android.core.TwitterAuthConfig;
 
 import ar.uba.fi.tdp2.trips.Common.BackendService;
+import ar.uba.fi.tdp2.trips.Common.CircleTransform;
 import ar.uba.fi.tdp2.trips.Common.User;
 import ar.uba.fi.tdp2.trips.Notifications.NotificationsActivity;
 import ar.uba.fi.tdp2.trips.R;
@@ -41,6 +43,7 @@ import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.ImageView;
 import android.widget.Toast;
 
 import com.google.android.gms.common.ConnectionResult;
@@ -131,6 +134,15 @@ public class InitialActivity extends AppCompatActivity implements GoogleApiClien
     private void checkUserAuthenticationToShowNotifications(NavigationView navigationView) {
         MenuItem notificationsMenuItem = navigationView.getMenu().findItem(R.id.nav_notifications);
         User user = User.getInstance(getSharedPreferences("user", 0));
+
+        if (user != null && user.profilePhotoUri != null) {
+            ImageView profilePic = (ImageView) navigationView.getHeaderView(0).findViewById(R.id.profile_pic);
+            Glide.with(this)
+                    .load(user.profilePhotoUri)
+                    .dontAnimate()
+                    .transform(new CircleTransform(InitialActivity.this))
+                    .into(profilePic);
+        }
 
         notificationsMenuItem.setVisible(user != null);
     }

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Common/CircleTransform.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Common/CircleTransform.java
@@ -1,0 +1,49 @@
+package ar.uba.fi.tdp2.trips.Common;
+
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapShader;
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.load.resource.bitmap.BitmapTransformation;
+
+public class CircleTransform extends BitmapTransformation {
+    public CircleTransform(Context context) {
+        super(context);
+    }
+
+    @Override protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight) {
+        return circleCrop(pool, toTransform);
+    }
+
+    private static Bitmap circleCrop(BitmapPool pool, Bitmap source) {
+        if (source == null) return null;
+
+        int size = Math.min(source.getWidth(), source.getHeight());
+        int x = (source.getWidth() - size) / 2;
+        int y = (source.getHeight() - size) / 2;
+
+        // TODO this could be acquired from the pool too
+        Bitmap squared = Bitmap.createBitmap(source, x, y, size, size);
+
+        Bitmap result = pool.get(size, size, Bitmap.Config.ARGB_8888);
+        if (result == null) {
+            result = Bitmap.createBitmap(size, size, Bitmap.Config.ARGB_8888);
+        }
+
+        Canvas canvas = new Canvas(result);
+        Paint paint = new Paint();
+        paint.setShader(new BitmapShader(squared, BitmapShader.TileMode.CLAMP, BitmapShader.TileMode.CLAMP));
+        paint.setAntiAlias(true);
+        float r = size / 2f;
+        canvas.drawCircle(r, r, r, paint);
+        return result;
+    }
+
+    @Override public String getId() {
+        return getClass().getName();
+    }
+}

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Common/User.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Common/User.java
@@ -43,6 +43,7 @@ public class User {
     public @SerializedName("tw_token") String twToken;
     public @SerializedName("tw_secret") String twSecret;
     public @SerializedName("device_token") String deviceToken;
+    public @SerializedName("profile_image") String profilePhotoUri;
 
     private User(int id, String token, boolean fbPublicProfile, boolean fbPost) {
         this.id     = id;
@@ -61,6 +62,7 @@ public class User {
 
     @Override
     public String toString() {
+        String photo = profilePhotoUri == null ? "" : "\n  profilePhotoUri: " + profilePhotoUri;
         return "User {\n  id: " + id + "\n  token: " + token + "\n fbPublicProfile: " + fbPublicProfile + "\n fbPost: " + fbPost + "\n}";
     }
 
@@ -94,6 +96,7 @@ public class User {
                 user.id = response.body().id;
                 user.token = response.body().token;
                 user.fbPublicProfile = true;
+                user.profilePhotoUri = response.body().profilePhotoUri;
                 user.persistUser(settings);
                 callback.onSuccess(user);
             }
@@ -133,6 +136,7 @@ public class User {
                 }
                 user.id = response.body().id;
                 user.token = response.body().token;
+                user.profilePhotoUri = response.body().profilePhotoUri;
                 Log.d("TRIPS", "got user: " + response.body().toString());
                 user.persistUser(settings);
                 callback.onSuccess(user);
@@ -164,6 +168,7 @@ public class User {
         boolean fbPost = settings.getBoolean("userFbPost", false);
         String fbUserId = settings.getString("fbUserId", null);
         String twUserId = settings.getString("twUserId", null);
+        String profilePhotoUri = settings.getString("profilePhotoUri", null);
         Log.d("TRIPS", userId + " " + userToken);
         if (userId != 0 && userToken != null) {
             User user = new User();
@@ -174,6 +179,7 @@ public class User {
             user.fbUserId = fbUserId;
             user.twUserId = twUserId;
             user.deviceToken = DeviceToken.getInstance().getDeviceToken();
+            user.profilePhotoUri = profilePhotoUri;
             return user;
         }
         return null;
@@ -187,6 +193,7 @@ public class User {
         editor.putBoolean("userFbPost", fbPost);
         editor.putString("fbUserId", fbUserId);
         editor.putString("twUserId", twUserId);
+        editor.putString("profilePhotoUri", profilePhotoUri);
         editor.commit();
         System.out.println(this);
     }

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Notifications/NotificationsActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Notifications/NotificationsActivity.java
@@ -18,13 +18,17 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.CompoundButton;
+import android.widget.ImageView;
 import android.widget.Toast;
+
+import com.bumptech.glide.Glide;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import ar.uba.fi.tdp2.trips.Cities.InitialActivity;
 import ar.uba.fi.tdp2.trips.Common.BackendService;
+import ar.uba.fi.tdp2.trips.Common.CircleTransform;
 import ar.uba.fi.tdp2.trips.Common.User;
 import ar.uba.fi.tdp2.trips.Common.Utils;
 import ar.uba.fi.tdp2.trips.R;
@@ -38,6 +42,7 @@ public class NotificationsActivity extends AppCompatActivity implements Navigati
     private List<Notification> notifications;
     private RecyclerView recyclerView;
     private boolean isSwitchChecked;
+    private NavigationView navigationView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -55,7 +60,7 @@ public class NotificationsActivity extends AppCompatActivity implements Navigati
         drawer.setDrawerListener(toggle);
         toggle.syncState();
 
-        NavigationView navigationView = (NavigationView) findViewById(R.id.nav_view);
+        navigationView = (NavigationView) findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
         navigationView.getMenu().findItem(R.id.nav_notifications).setChecked(true);
 
@@ -146,6 +151,27 @@ public class NotificationsActivity extends AppCompatActivity implements Navigati
         });
 
         return true;
+    }
+
+    private void checkUserAuthenticationToShowNotifications(NavigationView navigationView) {
+        MenuItem notificationsMenuItem = navigationView.getMenu().findItem(R.id.nav_notifications);
+        User user = User.getInstance(getSharedPreferences("user", 0));
+
+        if (user != null && user.profilePhotoUri != null) {
+            ImageView profilePic = (ImageView) navigationView.getHeaderView(0).findViewById(R.id.profile_pic);
+            Glide.with(this)
+                    .load(user.profilePhotoUri)
+                    .transform(new CircleTransform(NotificationsActivity.this))
+                    .into(profilePic);
+        }
+
+        notificationsMenuItem.setVisible(user != null);
+    }
+
+    @Override
+    public void onResume() {
+        checkUserAuthenticationToShowNotifications(navigationView);
+        super.onResume();
     }
 
     @SuppressWarnings("StatementWithEmptyBody")

--- a/app/src/main/res/layout/header_nav_drawer.xml
+++ b/app/src/main/res/layout/header_nav_drawer.xml
@@ -13,19 +13,18 @@
     android:theme="@style/ThemeOverlay.AppCompat.Dark">
 
     <ImageView
-        android:id="@+id/imageView"
-        android:layout_width="80dp"
-        android:layout_height="80dp"
-        android:paddingTop="@dimen/nav_header_vertical_spacing"
-        app:srcCompat="@drawable/trips_icon" />
+        android:id="@+id/profile_pic"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        />
 
     <TextView
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:paddingTop="@dimen/nav_header_vertical_spacing"
-        android:paddingStart="14dp"
-        android:paddingLeft="14dp"
         android:text="Trips"
         android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+
 
 </LinearLayout>

--- a/app/src/main/res/values-w820dp/dimens.xml
+++ b/app/src/main/res/values-w820dp/dimens.xml
@@ -2,5 +2,5 @@
     <!-- Example customization of dimensions originally defined in res/values/dimens.xml
          (such as screen margins) for screens with more than 820dp of available width. This
          would include 7" and 10" devices in landscape (~960dp and ~1280dp respectively). -->
-    <dimen name="activity_horizontal_margin">64dp</dimen>
+    <dimen name="activity_horizontal_margin">16dp</dimen>
 </resources>


### PR DESCRIPTION
Muestra la imagen del usuario (la de la red que devuelva el backend) en lugar del logo de la app en el sidebar, sobre el título de la app.

![image](https://cloud.githubusercontent.com/assets/8509529/26030059/049af53c-381d-11e7-9269-33024790f326.png)
