### PR TITLE
Log in and out from sidebar

### DIFF
--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Common/User.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Common/User.java
@@ -71,7 +71,7 @@ public class User {
         void onError(User user);
     }
 
-    public static void logout(final SharedPreferences settings) {
+    public static void logout(final SharedPreferences settings, final Callback callback) {
         BackendService backendService = BackendService.retrofit.create(BackendService.class);
         user = User.getInstance(settings);
         if (user == null) {
@@ -85,6 +85,7 @@ public class User {
                 LoginManager loginManager = LoginManager.getInstance();
                 loginManager.logOut();
                 user.deleteUser(settings);
+                callback.onSuccess(response.body());
                 user = null;
             }
 
@@ -93,6 +94,7 @@ public class User {
                 t.printStackTrace();
                 Toast.makeText(getApplicationContext(), "No se pudo conectar con el servidor", Toast.LENGTH_LONG).show(); // TODO internationalize
                 Log.d("TRIPS", t.toString());
+                callback.onError(null);
             }
         });
     }

--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Notifications/NotificationsActivity.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Notifications/NotificationsActivity.java
@@ -62,7 +62,6 @@ public class NotificationsActivity extends AppCompatActivity implements Navigati
 
         navigationView = (NavigationView) findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
-        navigationView.getMenu().findItem(R.id.nav_notifications).setChecked(true);
 
         recyclerView = (RecyclerView) findViewById(R.id.rvNotifications);
         LinearLayoutManager llm = new LinearLayoutManager(localContext);
@@ -153,24 +152,10 @@ public class NotificationsActivity extends AppCompatActivity implements Navigati
         return true;
     }
 
-    private void checkUserAuthenticationToShowNotifications(NavigationView navigationView) {
-        MenuItem notificationsMenuItem = navigationView.getMenu().findItem(R.id.nav_notifications);
-        User user = User.getInstance(getSharedPreferences("user", 0));
-
-        if (user != null && user.profilePhotoUri != null) {
-            ImageView profilePic = (ImageView) navigationView.getHeaderView(0).findViewById(R.id.profile_pic);
-            Glide.with(this)
-                    .load(user.profilePhotoUri)
-                    .transform(new CircleTransform(NotificationsActivity.this))
-                    .into(profilePic);
-        }
-
-        notificationsMenuItem.setVisible(user != null);
-    }
-
     @Override
     public void onResume() {
-        checkUserAuthenticationToShowNotifications(navigationView);
+        Utils.applySessionToDrawer(this, navigationView, User.getInstance(getSharedPreferences("user", 0)));
+        navigationView.getMenu().findItem(R.id.nav_notifications).setChecked(true);
         super.onResume();
     }
 
@@ -180,17 +165,25 @@ public class NotificationsActivity extends AppCompatActivity implements Navigati
         // Handle navigation view item clicks here.
         int id = item.getItemId();
 
-        if (id == R.id.nav_cities) {
-            //Ciudades
-            Intent intent = new Intent(this, InitialActivity.class);
-            startActivity(intent);
-        } else if (id == R.id.nav_notifications) {
-            //Notificaciones
-            //Aca no hace nada porque ya esta en ciudades
-            //TODO: Ver como hacer que ya aparezca marcado desde el menu.
-        } else if (id == R.id.nav_close_session) {
-            //Cerrar sesión
-            Toast.makeText(localContext, "Cerrando Sesión...", Toast.LENGTH_SHORT).show();
+        switch (id) {
+            case R.id.nav_cities:
+                Intent intent = new Intent(this, InitialActivity.class);
+                startActivity(intent);
+                break;
+            case R.id.nav_notifications:
+                // Do nothing
+                break;
+            case R.id.nav_close_session:
+                Utils.logout(this, navigationView, true);
+                break;
+            case R.id.nav_initiate_session:
+                // This is here just in case. The notifications page should never be
+                // visible when the user is logged out but, just in case, the button
+                // is functional.
+                Utils.login(this);
+                break;
+            default:
+                Log.d(Utils.LOGTAG, "Unknown navigation item selected. Id: " + id);
         }
 
         DrawerLayout drawer = (DrawerLayout) findViewById(R.id.drawer_layout);

--- a/app/src/main/res/menu/menu_nav_drawer.xml
+++ b/app/src/main/res/menu/menu_nav_drawer.xml
@@ -9,11 +9,18 @@
         <item
             android:id="@+id/nav_notifications"
             android:icon="@drawable/ic_notifications_black_24dp"
-            android:title="@string/nav_menu_notifications" />
+            android:title="@string/nav_menu_notifications"
+            android:visible="false"/>
+        <item
+            android:id="@+id/nav_initiate_session"
+            android:icon="@drawable/ic_power_settings_new_black_24dp"
+            android:title="@string/nav_menu_initiate_session"
+            />
         <item
             android:id="@+id/nav_close_session"
             android:icon="@drawable/ic_power_settings_new_black_24dp"
-            android:title="@string/nav_menu_close_session" />
+            android:title="@string/nav_menu_close_session"
+            android:visible="false"/>
     </group>
 
 </menu>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -53,7 +53,7 @@
     <string name="google_maps_not_installed">Google Maps is not installed</string>
     <string name="out_of">out of</string>
     <string name="nav_menu_cities">Cities</string>
-    <string name="nav_menu_close_session">Close session</string>
+    <string name="nav_menu_close_session">Log out</string>
     <string name="nav_menu_notifications">Notifications</string>
     <string name="manage_sessions">Manage sessions</string>
     <string name="days_unit">days</string>
@@ -67,4 +67,8 @@
     <string name="ago">%1$d %2$s ago</string>
     <string name="just_now">Just now</string>
     <string name="login_required_for_review">You must login first to write a review</string>
+    <string name="nav_menu_initiate_session">Log in</string>
+    <string name="could_not_log_out">Could not log out</string>
+    <string name="logged_out">Logged out</string>
+    <string name="logging_out">Logging out...</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,5 +81,9 @@
     <string name="manage_sessions">Administrar sesiones</string>
     <string name="title_activity_notifications" translatable="false">Notificaciones</string>
     <string name="login_required_for_review">Debes iniciar sesión para escribir una reseña</string>
-    <string name="gcm_defaultSenderId">295203185705</string>
+    <string name="gcm_defaultSenderId" translatable="false">295203185705</string>
+    <string name="nav_menu_initiate_session">Iniciar sesión</string>
+    <string name="logging_out">Cerrando Sesión...</string>
+    <string name="logged_out">Sesión cerrada</string>
+    <string name="could_not_log_out">No se pudo cerrar sesión</string>
 </resources>


### PR DESCRIPTION
El usuario puede loguearse y desloguearse desde el sidebar.

Al loguearse:
- Se muestra la foto del usuario
- Se cambia el botón de `inicar sesión` por el de `cerrar sesión`
- Aparece la opción de ir a las notificaciones


Al desloguarse:
- Desaparece la foto del usuario
- Se cambia el botón de `cerrar sesión` por el de `iniciar sesión`
- Desaparece la opción de ir a las notificaciones
- **Si estaba en la pantalla de notificaciones, se cierra esa activity y vuelve a la lista de ciudades (que es el único lugar desde el que se puede llegar a la lista de notificaciones)**

Extraje todo lo que pude de la lógica a la clase `Utils`, para reusarla más fácil desde la lista de ciudades y de la de notificaciones. También tuve que agregarle un callback al `User.logout` para poder hacer los cambios que dice ahí arriba. No es necesario en el login, porque eso redirige a otra pantalla, lo que hace que al volver se ejecute el `onResume`.