### PR TITLE
Handle 403 when posting reviews

### DIFF
--- a/app/src/main/java/ar/uba/fi/tdp2/trips/Reviews/Review.java
+++ b/app/src/main/java/ar/uba/fi/tdp2/trips/Reviews/Review.java
@@ -27,4 +27,8 @@ public class Review {
         return "Review {\n  rating: " + String.valueOf(rating) + "\n  user: " + user +
                 "\n  date: " + date + "\n  text: " + text + "\n}";
     }
+
+    public Review clone() {
+        return new Review(rating, user, date, text);
+    }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -67,4 +67,6 @@
     <string name="ago">%1$d %2$s ago</string>
     <string name="just_now">Just now</string>
     <string name="login_required_for_review">You must login first to write a review</string>
+    <string name="user_blocked">You\'ve been blocked by an administrator</string>
+    <string name="understood">UNDERSTOOD</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,4 +82,6 @@
     <string name="title_activity_notifications" translatable="false">Notificaciones</string>
     <string name="login_required_for_review">Debes iniciar sesión para escribir una reseña</string>
     <string name="gcm_defaultSenderId">295203185705</string>
+    <string name="understood">ENTENDIDO</string>
+    <string name="user_blocked">Fuiste bloqueado por un administrador</string>
 </resources>


### PR DESCRIPTION
Si un usuario intenta postear una review y fue bloqueado, al recibir el 403 del backend, se muestra una alerta que le informa al usuario que fue bloqueado. La review que se ve en el detalle de la atracción también se resetea (a lo que había antes de intentar mandar la nueva review).

A futuro (no este cuatrI 😛 ) se podría agregar otro botón en ese mismo modal que permita mandar un mail a los administradores pidiendo que te desbloqueen o algo por el estilo.

![image](https://cloud.githubusercontent.com/assets/8509529/26037284/88c6e786-38c6-11e7-87ae-a837e979c5ac.png) 
![image](https://cloud.githubusercontent.com/assets/8509529/26037296/cf5af3ea-38c6-11e7-98e1-f35dff1ebbbd.png)


